### PR TITLE
【chapter quest】のパターンでも認識されるようにする。

### DIFF
--- a/harvest/chalicelib/freequest.py
+++ b/harvest/chalicelib/freequest.py
@@ -69,8 +69,21 @@ def _build_db(freequests: List[Dict[str, str]]) -> Dict[str, str]:
 
         if f'{chapter}\t{place}' in d:
             raise KeyError(f'key "{chapter} {place}" has already registered')
-
         d[f'{chapter}\t{place}'] = qid
+
+        # 修練場のようにクエスト名がないパターンがあるので
+        # 存在チェックが必要。
+        if quest:
+            if f'{chapter}\t{quest}' in d:
+                # これらは登録済みで正しい
+                if (chapter, place, quest) in quests_in_same_place:
+                    continue
+                # それ以外が二重に登録されるのはDBの設定ミス
+                else:
+                    raise KeyError(
+                        f'key "{chapter} {quest}" has already registered'
+                    )
+            d[f'{chapter}\t{quest}'] = qid
 
     # 周回カウンタに登録されているクエスト名が特殊
     d['オルレアン\tティエール(刃物の町)'] = d['オルレアン\tティエール']

--- a/harvest/chalicelib/freequest.py
+++ b/harvest/chalicelib/freequest.py
@@ -68,22 +68,26 @@ def _build_db(freequests: List[Dict[str, str]]) -> Dict[str, str]:
                 continue
 
         if f'{chapter}\t{place}' in d:
-            raise KeyError(f'key "{chapter} {place}" has already registered')
+            raise KeyError(
+                f'key "{chapter} {place}" has already been registered'
+            )
         d[f'{chapter}\t{place}'] = qid
 
         # 修練場のようにクエスト名がないパターンがあるので
         # 存在チェックが必要。
-        if quest:
-            if f'{chapter}\t{quest}' in d:
-                # これらは登録済みで正しい
-                if (chapter, place, quest) in quests_in_same_place:
-                    continue
-                # それ以外が二重に登録されるのはDBの設定ミス
-                else:
-                    raise KeyError(
-                        f'key "{chapter} {quest}" has already registered'
-                    )
-            d[f'{chapter}\t{quest}'] = qid
+        if len(quest) == 0:
+            continue
+
+        if f'{chapter}\t{quest}' in d:
+            # これらは登録済みで正しい
+            if (chapter, place, quest) in quests_in_same_place:
+                continue
+            # それ以外が二重に登録されるのはDBの設定ミス
+            else:
+                raise KeyError(
+                    f'key "{chapter} {quest}" has already been registered'
+                )
+        d[f'{chapter}\t{quest}'] = qid
 
     # 周回カウンタに登録されているクエスト名が特殊
     d['オルレアン\tティエール(刃物の町)'] = d['オルレアン\tティエール']


### PR DESCRIPTION
現在は一部のクエストを除き `【chapter place】` でしかDBを構築していないため、このようにクエスト名を用いるとイベントクエスト扱いになる。
`freequest_db` の構築を見直すことで、この問題を解決する。

![image](https://user-images.githubusercontent.com/696577/88069093-ff391a80-cbab-11ea-8457-c021344284d1.png)
