### PR TITLE
ツイートログ管理コマンド実装。

### DIFF
--- a/harvest/app.py
+++ b/harvest/app.py
@@ -166,14 +166,14 @@ def collect_tweets(event):
     )
     app.log.info('collected %s tweets', len(tweets))
 
+    if len(tweets) == 0:
+        return
+
     tweet_log_file = '{}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'))
     app.log.info('tweet_log: %s', tweet_log_file)
     tweet_storage.put(tweet_log_file, tweets)
 
     render_contents(app, tweets)
-
-    if len(tweets) == 0:
-        return
 
     latest_tweet = tweets[0]
     app.log.info('saving the latest tweet id: %s', latest_tweet.tweet_id)

--- a/harvest/main.py
+++ b/harvest/main.py
@@ -45,8 +45,12 @@ def main(args):
             exclude_accounts=settings.ExcludeAccounts,
         )
 
+        if len(tweets) == 0:
+            return
+
         key = '{}.json'.format(datetime.now().strftime('%Y%m%d_%H%M%S'))
         tweet_storage.put(key, tweets)
+
     else:
         tweets = tweet_storage.readall()
 

--- a/harvest/s3tweets.py
+++ b/harvest/s3tweets.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+"""
+    S3 に補完されたツイートログを管理するコマンド。
+"""
+
+import argparse
+import json
+import logging
+import pathlib
+from operator import itemgetter
+from typing import Any, Dict, List
+
+import boto3  # type: ignore
+
+from chalicelib import settings
+
+logger = logging.getLogger(__name__)
+s3 = boto3.resource('s3')
+s3bucket = s3.Bucket(settings.S3Bucket)
+
+
+def exec_pull(args):
+    """
+        S3 の JSON ファイルを一括でダウンロードする。
+    """
+    output_dir = pathlib.Path(args.output_dir)
+    output_dir.mkdir(exist_ok=True)
+
+    object_summary_iterator = s3bucket.objects.filter(Prefix=settings.TweetStorageDir)
+
+    for object_summary in object_summary_iterator:
+        key = object_summary.key
+        logger.info('s3: %s', key)
+
+        name = key.replace(settings.TweetStorageDir + '/', '')
+        output = output_dir / name
+        logger.info(' --> %s', output)
+
+        resp = object_summary.get()
+        with open(output, 'wb') as fp:
+            fp.write(resp['Body'].read())
+
+
+def merge(files: List[pathlib.Path]) -> List[Dict[str, Any]]:
+    merged_tweets = []
+    for filepath in files:
+        with open(filepath) as fp:
+            tweets = json.load(fp)
+        if len(tweets) == 0:
+            continue
+        merged_tweets.extend(tweets)
+    logger.info('merged tweets: %s', len(merged_tweets))
+    tweet_set = set([json.dumps(tw) for tw in merged_tweets])
+    distinct_tweets = [json.loads(tw) for tw in tweet_set]
+    logger.info('distinct tweets: %s', len(distinct_tweets))
+    return sorted(distinct_tweets, key=itemgetter('id'))
+
+
+def exec_merge(args):
+    """
+        JSON ファイルを日付単位でマージする。
+    """
+    target_dir = pathlib.Path(args.target_dir)
+    output_dir = pathlib.Path(args.output_dir)
+    output_dir.mkdir(exist_ok=True)
+
+    files = target_dir.glob('*.json')
+    partition: Dict[str, List[pathlib.Path]] = {}
+
+    for filepath in files:
+        date = filepath.name[:8]
+        logger.info('%s %s', filepath.name, date)
+        if date not in partition:
+            partition[date] = []
+        partition[date].append(filepath)
+
+    for date, files in partition.items():
+        logger.info(date)
+        merged = merge(files)
+        filename = f'{date}.json'
+        filepath = output_dir / filename
+        logger.info(f'save tweets to {filepath}')
+        with open(filepath, 'w') as fp:
+            json.dump(merged, fp, ensure_ascii=False)
+
+
+def exec_push(args):
+    """
+        JSON ファイルを S3 にアップロードする。
+    """
+    target_dir = pathlib.Path(args.target_dir)
+    files = target_dir.glob('*.json')
+    basepath = pathlib.PurePosixPath(settings.TweetStorageDir)
+
+    for filepath in files:
+        key = str(basepath / filepath.name)
+        src = str(filepath)
+        logger.info(f'{src} -> s3: {key}')
+        if args.dry_run:
+            logger.info('skip uploading')
+            continue
+        s3bucket.upload_file(
+            src,
+            key,
+            ExtraArgs={'ContentType': 'application/json'},
+        )
+
+
+def exec_clean(args):
+    """
+        target_dir にある JSON ファイルと同名のファイルを
+        S3 から削除する。
+    """
+    object_summary_iterator = s3bucket.objects.filter(Prefix=settings.TweetStorageDir)
+    output_dir = pathlib.Path(args.target_dir)
+
+    for object_summary in object_summary_iterator:
+        key = object_summary.key
+        logger.debug('s3: %s', key)
+
+        name = key.replace(settings.TweetStorageDir + '/', '')
+        output = output_dir / name
+        logger.debug('local: %s, exists: %s', output, output.exists())
+
+        if output.exists():
+            if args.dry_run:
+                logger.info('(fake) deleted: %s', key)
+            else:
+                resp = object_summary.delete()
+                logger.debug(resp)
+                logger.info('deleted: %s', key)
+        else:
+            logger.info('skip deleting: %s', key)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser()
+
+    def add_common_arguments(subparser):
+        subparser.add_argument(
+            '--loglevel',
+            choices=('debug', 'info', 'warning'),
+            default='info',
+        )
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    pull_parser = subparsers.add_parser('pull')
+    pull_parser.add_argument('-o', '--output-dir', default='output/s3tweets')
+    add_common_arguments(pull_parser)
+    pull_parser.set_defaults(func=exec_pull)
+
+    marge_parser = subparsers.add_parser('merge')
+    marge_parser.add_argument('-d', '--target-dir', default='output/s3tweets')
+    marge_parser.add_argument('-o', '--output-dir', default='output/mergedtweets')
+    add_common_arguments(marge_parser)
+    marge_parser.set_defaults(func=exec_merge)
+
+    push_parser = subparsers.add_parser('push')
+    push_parser.add_argument('-d', '--target-dir', default='output/mergedtweets')
+    push_parser.add_argument('--dry-run', action='store_true')
+    add_common_arguments(push_parser)
+    push_parser.set_defaults(func=exec_push)
+
+    clean_parser = subparsers.add_parser('clean')
+    clean_parser.add_argument('-d', '--target-dir', default='output/s3tweets')
+    clean_parser.add_argument('--dry-run', action='store_true')
+    add_common_arguments(clean_parser)
+    clean_parser.set_defaults(func=exec_clean)
+    return parser
+
+
+if __name__ == '__main__':
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if hasattr(args, 'func'):
+        logging.basicConfig(
+            level=args.loglevel.upper(),
+            format='%(asctime)s [%(levelname)s] %(message)s',
+        )
+        args.func(args)
+    else:
+        parser.print_usage()


### PR DESCRIPTION
fixes #12 

とりあえず日付単位でマージできるようにした。
#7 の件でエラーが繰り返し発生していたときに結構な量のゴミ（＊）がたまっていたらしい。それも時間がかかる原因の一つだったかもしれない。

（＊）#7 のエラーのときにツイートのパースでエラーが発生しプログラムが中断していたため、latest_tweet のマークが動かずにフェッチ済みのツイートを15分おきに繰り返し取得することとなった。よって、重複する無駄なデータが蓄積されていた。

また、ツイート収集時に件数0件の場合はJSONファイルを作らないように合わせて修正した。
https://github.com/fgosc/fgo_harvest/issues/12#issuecomment-662886867