### PR TITLE
pytz を使わずとも標準ライブラリだけで timezone の管理ができるので pytz は削除。

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,13 +7,11 @@ verify_ssl = true
 pytest = "*"
 rope = "*"
 flake8 = "*"
-pyflakes = "*"
 
 [packages]
 tweepy = "*"
 boto3 = "*"
 jinja2 = "*"
-pytz = "*"
 chalice = "*"
 mypy = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bf31d2e1e1658fbaeaa38065c036340c08f90fb3b5fcf6daa3a4ad6fd764e470"
+            "sha256": "fa4a742ec318e05b82dd5b9410ca15803b8db78f5e9f4e27963adf6208184aec"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,18 +26,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:e6ab26155b2f83798218106580ab2b3cd47691e25aba912e0351502eda8d86e0",
-                "sha256:f7aa33b382cc9e73ef7f590b885e72732ad2bd9628c5e312c9aeb8ba011c6820"
+                "sha256:4196b418598851ffd10cf9d1606694673cbfeca4ddf8b25d4e50addbd2fc60bf",
+                "sha256:69ad8f2184979e223e12ee3071674fdf910983cf9f4d6f34f7ec407b089064b5"
             ],
             "index": "pypi",
-            "version": "==1.14.20"
+            "version": "==1.14.54"
         },
         "botocore": {
             "hashes": [
-                "sha256:d1bf8c2085719221683edf54913c6155c68705f26ab4a72c45e4de5176a8cf7b",
-                "sha256:e7fee600092b51ca8016c541d5c50a8b39179d5c184ec3fd430400d99ba0c55a"
+                "sha256:6fe05837646447d61acdaf1e3401b92cd9309f00b19c577a50d0ade7735a3403",
+                "sha256:9e493a21e6a8d45c631eb2952ae8e1d0a31b9984546d4268ea10c0c33e2435ce"
             ],
-            "version": "==1.17.20"
+            "version": "==1.17.54"
         },
         "certifi": {
             "hashes": [
@@ -48,11 +48,11 @@
         },
         "chalice": {
             "hashes": [
-                "sha256:9e4c000b8e8f6a5286fb0895904f2c82e1975bb60cd5df745807421c36820ce6",
-                "sha256:bfacac7c9e9b17c30094a8789ec495b50f43af9df037d1f8903bfd68c7b946e9"
+                "sha256:cab42ebb15d1e72cb97440353b98c5f436d7234b206904bfb37794b2d2ec647d",
+                "sha256:d18aeb83898f4d15bea822e07d862baad375b6507f9a7aa327399d163a5d328e"
             ],
             "index": "pypi",
-            "version": "==1.15.1"
+            "version": "==1.18.1"
         },
         "chardet": {
             "hashes": [
@@ -200,14 +200,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
-        "pytz": {
-            "hashes": [
-                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
-                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
-            ],
-            "index": "pypi",
-            "version": "==2020.1"
-        },
         "pyyaml": {
             "hashes": [
                 "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
@@ -225,6 +217,9 @@
             "version": "==5.3.1"
         },
         "requests": {
+            "extras": [
+                "socks"
+            ],
             "hashes": [
                 "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
                 "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
@@ -257,11 +252,11 @@
         },
         "tweepy": {
             "hashes": [
-                "sha256:8abd828ba51a85a2b5bb7373715d6d3bb32d18ac624e3a4db02e4ef8ab48316b",
-                "sha256:ecc7f200c86127903017e48824efd008734814e95f3e8e9b45ce0f4120dd08db"
+                "sha256:3b3780df00eaa937bbd5427d2011e4b3bcb6a29a87bb4cbb4addfc47850e46a5",
+                "sha256:bfd19a5c11f35f7f199c795f99d9cbf8a52eb33f0ecfb6c91ee10b601180f604"
             ],
             "index": "pypi",
-            "version": "==3.8.0"
+            "version": "==3.9.0"
         },
         "typed-ast": {
             "hashes": [
@@ -291,27 +286,27 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
-                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
-                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "version": "==3.7.4.2"
+            "version": "==3.7.4.3"
         },
         "urllib3": {
             "hashes": [
-                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
-                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
             "markers": "python_version != '3.4'",
-            "version": "==1.25.9"
+            "version": "==1.25.10"
         },
         "wheel": {
             "hashes": [
-                "sha256:8788e9155fe14f54164c1b9eb0a319d98ef02c160725587ad60f14ddc57b6f96",
-                "sha256:df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e"
+                "sha256:497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2",
+                "sha256:99a22d87add3f634ff917310a3d87e499f19e663413a52eb9232c447aa646c9f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.34.2"
+            "version": "==0.35.1"
         }
     },
     "develop": {
@@ -331,6 +326,13 @@
             "index": "pypi",
             "version": "==3.8.3"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437",
+                "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"
+            ],
+            "version": "==1.0.1"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
@@ -340,11 +342,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5",
-                "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"
+                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
+                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==8.4.0"
+            "version": "==8.5.0"
         },
         "packaging": {
             "hashes": [
@@ -383,7 +385,7 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
         "pyparsing": {
@@ -396,11 +398,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1",
-                "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"
+                "sha256:85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4",
+                "sha256:8b6007800c53fdacd5a5c192203f4e531eb2a1540ad9c752e052ec0f7143dbad"
             ],
             "index": "pypi",
-            "version": "==5.4.3"
+            "version": "==6.0.1"
         },
         "rope": {
             "hashes": [
@@ -417,12 +419,12 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
-        "wcwidth": {
+        "toml": {
             "hashes": [
-                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
-                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
             ],
-            "version": "==0.2.5"
+            "version": "==0.10.1"
         }
     }
 }

--- a/harvest/chalicelib/timezone.py
+++ b/harvest/chalicelib/timezone.py
@@ -1,9 +1,8 @@
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
-import pytz
-
-Local = pytz.timezone('Asia/Tokyo')
+Local = timezone(timedelta(hours=+9), 'JST')
+UTC = timezone.utc
 
 
 def now():
-    return datetime.now(tz=pytz.UTC).astimezone(Local)
+    return datetime.now(tz=UTC).astimezone(Local)

--- a/harvest/chalicelib/twitter.py
+++ b/harvest/chalicelib/twitter.py
@@ -10,7 +10,6 @@ from typing import (
     cast, Any, Dict, List, Optional, Union,
 )
 
-import pytz
 import tweepy  # type: ignore
 
 from . import freequest, settings, storage, timezone
@@ -94,7 +93,8 @@ class TweetCopy:
     @property
     def timestamp(self):
         # tweepy で取得した時刻は UTC かつタイムゾーン情報が付加されていない。
-        return pytz.UTC.localize(self.created_at).astimezone(timezone.Local)
+        return self.created_at.replace(tzinfo=timezone.UTC)\
+            .astimezone(timezone.Local)
 
     @staticmethod
     def retrieve(data: Dict[str, Union[int, str]]) -> TweetCopy:
@@ -156,7 +156,8 @@ class ParseErrorTweet:
     @property
     def timestamp(self):
         # tweepy で取得した時刻にはタイムゾーン情報が付加されていない。
-        return pytz.UTC.localize(self.created_at).astimezone(timezone.Local)
+        return self.created_at.replace(tzinfo=timezone.UTC)\
+            .astimezone(timezone.Local)
 
     @property
     def short_text(self):

--- a/harvest/chalicelib/twitter_test.py
+++ b/harvest/chalicelib/twitter_test.py
@@ -1,8 +1,7 @@
 from collections import namedtuple
 from datetime import datetime
 
-import pytz
-
+from . import timezone
 from . import twitter
 
 MockTweet = namedtuple('MockTweet', ['id', 'user', 'full_text', 'created_at'])
@@ -35,8 +34,8 @@ QP(+194千)50-QP(+195千)58
     assert parsed.reporter == 'testuser'
     assert parsed.chapter == 'シャーロット'
     assert parsed.place == 'ゴールドラッシュ'
-    tz = pytz.timezone('Asia/Tokyo')
-    assert parsed.timestamp == tz.localize(datetime(2020, 1, 2, 12, 4, 5))
+    tz = timezone.Local
+    assert parsed.timestamp == datetime(2020, 1, 2, 12, 4, 5, tzinfo=tz)
     assert parsed.items == {
         '塵': '643',
         '証': '487',

--- a/harvest/requirements-dev.txt
+++ b/harvest/requirements-dev.txt
@@ -1,20 +1,21 @@
 -i https://pypi.org/simple
 attrs==19.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-boto3==1.14.20
-botocore==1.17.20
+boto3==1.14.54
+botocore==1.17.54
 certifi==2020.6.20
-chalice==1.15.1
+chalice==1.18.1
 chardet==3.0.4
 click==7.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 docutils==0.15.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 enum-compat==0.0.3
 flake8==3.8.3
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+iniconfig==1.0.1
 jinja2==2.11.2
 jmespath==0.10.0; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 markupsafe==1.1.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 mccabe==0.6.1
-more-itertools==8.4.0; python_version >= '3.5'
+more-itertools==8.5.0; python_version >= '3.5'
 mypy-extensions==0.4.3
 mypy==0.782
 oauthlib==3.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
@@ -22,21 +23,20 @@ packaging==20.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.
 pluggy==0.13.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 py==1.9.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pycodestyle==2.6.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pyflakes==2.2.0
+pyflakes==2.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pysocks==1.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pytest==5.4.3
+pytest==6.0.1
 python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pytz==2020.1
 pyyaml==5.3.1
 requests-oauthlib==1.3.0
-requests==2.24.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+requests[socks]==2.24.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 rope==0.17.0
 s3transfer==0.3.3
 six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-tweepy==3.8.0
+toml==0.10.1
+tweepy==3.9.0
 typed-ast==1.4.1
-typing-extensions==3.7.4.2
-urllib3==1.25.9; python_version != '3.4'
-wcwidth==0.2.5
-wheel==0.34.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+typing-extensions==3.7.4.3
+urllib3==1.25.10; python_version != '3.4'
+wheel==0.35.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/harvest/requirements.txt
+++ b/harvest/requirements.txt
@@ -1,9 +1,9 @@
 -i https://pypi.org/simple
 attrs==19.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-boto3==1.14.20
-botocore==1.17.20
+boto3==1.14.54
+botocore==1.17.54
 certifi==2020.6.20
-chalice==1.15.1
+chalice==1.18.1
 chardet==3.0.4
 click==7.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 docutils==0.15.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
@@ -17,14 +17,13 @@ mypy==0.782
 oauthlib==3.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pysocks==1.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pytz==2020.1
 pyyaml==5.3.1
 requests-oauthlib==1.3.0
-requests==2.24.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+requests[socks]==2.24.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 s3transfer==0.3.3
 six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-tweepy==3.8.0
+tweepy==3.9.0
 typed-ast==1.4.1
-typing-extensions==3.7.4.2
-urllib3==1.25.9; python_version != '3.4'
-wheel==0.34.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+typing-extensions==3.7.4.3
+urllib3==1.25.10; python_version != '3.4'
+wheel==0.35.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'


### PR DESCRIPTION
デプロイパッケージを軽くする意味でも、使わないライブラリは減らした方がよい。