### PR TITLE
フリクエ名の推測をやめる

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,6 @@ boto3 = "*"
 jinja2 = "*"
 chalice = "*"
 mypy = "*"
-python-levenshtein = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3bf81327ced7d994af143be59390d22653cdd2c7b86c1f6ef55561f5cc15c3dc"
+            "sha256": "fa4a742ec318e05b82dd5b9410ca15803b8db78f5e9f4e27963adf6208184aec"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,33 +26,33 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:89786469ff343381f9066d3c7f27ba3526b1563facd59428eb30bfaca43d3831",
-                "sha256:f95052292691568d158c483caf25202bbd466e2435f80c090e53aa9be2ee84b2"
+                "sha256:13e6ab0abe10b4de54583067d12ed48c8477d91b7a7a8e6097d366a2a3631d17",
+                "sha256:fb25ec578fe59aee298da2c976e2bcfd79a2eabead386e8e4f68bb3eb4ec50b3"
             ],
             "index": "pypi",
-            "version": "==1.16.31"
+            "version": "==1.16.25"
         },
         "botocore": {
             "hashes": [
-                "sha256:1e5712d53ecdefb0279dc45abef32bd9499f92800ddd89038a8dddb99423f940",
-                "sha256:624e1d4ce704494f73440c416624481d4ff283049b17d12e06890b79f2ac177d"
+                "sha256:4e488351f399501a78b16e1dc466e505ccf63897c936030c56c6d3c37e57939c",
+                "sha256:ccaf3979590b72625b3699d93dabf48f350f9a3304c127fc6830e8ac842b0d96"
             ],
-            "version": "==1.19.31"
+            "version": "==1.19.25"
         },
         "certifi": {
             "hashes": [
-                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
-                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+                "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd",
+                "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"
             ],
-            "version": "==2020.12.5"
+            "version": "==2020.11.8"
         },
         "chalice": {
             "hashes": [
-                "sha256:73149f6a71aa1310f3d000110a915164a72f1d2dc7cd4d37d18a952b0e0c78ac",
-                "sha256:c86e9697e09c325932456052fa17c247d047be5bd9a0653dd3ad633a43b2abc2"
+                "sha256:730b3f560414e02473626edf4e0b0cd35608ce926abb27aa8a005e63a4c4ea9f",
+                "sha256:fb3580272cc66ba0fd59914b7ac395d2da6b9b32b11dc7557aa80a0ae7cccf3c"
             ],
             "index": "pypi",
-            "version": "==1.21.5"
+            "version": "==1.21.4"
         },
         "chardet": {
             "hashes": [
@@ -191,26 +191,19 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
-        "python-levenshtein": {
-            "hashes": [
-                "sha256:033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1"
-            ],
-            "index": "pypi",
-            "version": "==0.12.0"
-        },
         "pyyaml": {
             "hashes": [
-                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
-                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
-                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
                 "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e",
-                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
                 "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
-                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
                 "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
                 "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
                 "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a",
-                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
                 "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
                 "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
             ],
@@ -260,36 +253,36 @@
         },
         "typed-ast": {
             "hashes": [
-                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
-                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
-                "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d",
-                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
-                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
-                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
-                "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c",
-                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
-                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
-                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
-                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
                 "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
                 "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
                 "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d",
-                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
-                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
-                "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c",
-                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
-                "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395",
-                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
-                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
-                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
-                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
-                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
                 "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072",
-                "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298",
-                "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91",
-                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
                 "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f",
-                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+                "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"
             ],
             "version": "==1.4.1"
         },
@@ -311,11 +304,11 @@
         },
         "wheel": {
             "hashes": [
-                "sha256:906864fb722c0ab5f2f9c35b2c65e3af3c009402c108a709c0aca27bc2c9187b",
-                "sha256:aaef9b8c36db72f8bf7f1e54f85f875c4d466819940863ca0b3f3f77f0a1646f"
+                "sha256:497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2",
+                "sha256:99a22d87add3f634ff917310a3d87e499f19e663413a52eb9232c447aa646c9f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.36.1"
+            "version": "==0.35.1"
         }
     },
     "develop": {

--- a/harvest/.chalice/config.json
+++ b/harvest/.chalice/config.json
@@ -6,7 +6,7 @@
       "api_gateway_stage": "api",
       "lambda_functions": {
         "rebuild_outputs": {
-          "lambda_timeout": 600,
+          "lambda_timeout": 300,
           "lambda_memory_size": 256
         }
       }

--- a/harvest/chalicelib/freequest.py
+++ b/harvest/chalicelib/freequest.py
@@ -3,9 +3,7 @@ import os
 from base64 import urlsafe_b64encode
 from hashlib import md5
 from logging import getLogger
-from typing import Dict, Iterable, List, Optional, Set, Tuple, cast
-
-import Levenshtein  # type: ignore
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 logger = getLogger(__name__)
 
@@ -65,39 +63,6 @@ class Detector:
 
     def get_quest_name(self, qid: str) -> str:
         return self.quest_reverse_index[qid]
-
-    def search_bestmatch_freequest(self, expr: str) -> Optional[str]:
-        min_distance = 10
-        min_candidate = None
-
-        for candidate in self.freequest_db:
-            title = candidate.replace('\t', ' ')
-            # 投稿場所は正しいが前後に余計な情報がついているケースを
-            # これでカバーできる。
-            if title in expr:
-                logger.debug(
-                    'candidate: %s, title: %s, expr: %s',
-                    candidate, title, expr,
-                )
-                return self.freequest_db[candidate]
-
-            distance = Levenshtein.distance(expr, candidate)
-            if distance < min_distance:
-                min_distance = distance
-                min_candidate = candidate
-
-        logger.debug(
-            'best match: %s, disatnce: %s',
-            min_candidate,
-            min_distance,
-        )
-
-        if min_distance < 3:
-            logger.debug('use bestmatch freequest')
-            return self.freequest_db[cast(str, min_candidate)]
-
-        logger.debug('ignore bestmatch freequest: score is not enough')
-        return None
 
     def find_freequest(self, expr: str) -> Optional[Tuple[str, str]]:
         """
@@ -189,11 +154,6 @@ def _build_db(freequests: List[Dict[str, str]]) -> Dict[str, str]:
                 if alt_quest:
                     d[(f'{alt_place}\t{alt_quest}')] = qid
 
-            # クエスト名だけの投稿
-            d[f'{quest}\t'] = qid
-            if alt_quest:
-                d[f'{alt_quest}\t'] = qid
-
         if (chapter, place, quest) not in quests_in_same_place \
                 or quest in prior_in_same_place:
 
@@ -209,6 +169,11 @@ def _build_db(freequests: List[Dict[str, str]]) -> Dict[str, str]:
             d[f'{place}\t'] = qid
             if alt_place:
                 d[f'{alt_place}\t'] = qid
+
+        # クエスト名だけの投稿
+        d[f'{quest}\t'] = qid
+        if alt_quest:
+            d[f'{alt_quest}\t'] = qid
 
     # 周回カウンタに登録されているクエスト名が特殊
     d['オルレアン\tティエール(刃物の町)'] = d['オルレアン\tティエール']

--- a/harvest/chalicelib/freequest_test.py
+++ b/harvest/chalicelib/freequest_test.py
@@ -71,18 +71,3 @@ testdata_get_quest_id = [
 def test_get_quest_id(chapter, place, expected):
     assert freequest.defaultDetector.get_quest_id(
         chapter, place, 2020) == expected
-
-
-testdata_search_bestmatch_freequest = [
-    ('大江山 鬼の住み処', '20g12'),
-    ('地獄界曼荼羅 平安京 三条三坊 鬼の遊び場', '20g13'),
-]
-
-
-@pytest.mark.parametrize(
-    'candidate,expected',
-    testdata_search_bestmatch_freequest,
-)
-def test_search_bestmatch_freequest(candidate, expected):
-    assert freequest.defaultDetector.\
-        search_bestmatch_freequest(candidate) == expected

--- a/harvest/chalicelib/recording.py
+++ b/harvest/chalicelib/recording.py
@@ -169,7 +169,9 @@ class PartitioningRuleByQuest:
         report: twitter.RunReport,
     ) -> None:
 
-        qid = report.quest_id
+        detector = freequest.defaultDetector
+        year = report.timestamp.year
+        qid = detector.get_quest_id(report.chapter, report.place, year)
         if qid not in partitions:
             partitions[qid] = []
         partitions[qid].append(report)
@@ -233,30 +235,20 @@ class PartitioningRuleByUserList:
 class QuestListElement:
     def __init__(
         self,
-        quest_id: str,
         chapter: str,
         place: str,
         timestamp: datetime,
-        is_freequest: bool,
         count: int = 1,
     ):
-        self.quest_id = quest_id
+        detector = freequest.defaultDetector
+        self.quest_id = detector.get_quest_id(chapter, place, timestamp.year)
+        self.is_freequest = detector.is_freequest(chapter, place)
+        self.quest_name = detector.get_quest_name(self.quest_id)
         self.chapter = chapter
         self.place = place
         self.since = timestamp
         self.latest = timestamp
-        self.is_freequest = is_freequest
         self.count = count
-        detector = freequest.defaultDetector
-        try:
-            self.quest_name = detector.get_quest_name(quest_id)
-        except KeyError:
-            _qid = detector.get_quest_id(chapter, place, timestamp.year)
-            if quest_id != _qid:
-                raise ValueError(
-                    f'qid mismatch: {quest_id} != {_qid} ({chapter} {place})'
-                )
-            self.quest_name = detector.get_quest_name(quest_id)
 
     def countup(self, timestamp: datetime) -> None:
         self.count += 1
@@ -336,13 +328,7 @@ class PartitioningRuleByQuestList:
 
         quest_list = json.loads(text, object_hook=_load_hook)
         for q in quest_list:
-            e = QuestListElement(
-                q['id'],
-                q['chapter'],
-                q['place'],
-                q['since'],
-                q['is_freequest'],
-            )
+            e = QuestListElement(q['chapter'], q['place'], q['since'])
             if e.quest_id != q['id']:
                 logger.error(f'json: {q}')
                 raise ValueError('incorrect data: {}'.format(q['id']))
@@ -357,13 +343,7 @@ class PartitioningRuleByQuestList:
         report: twitter.RunReport,
     ) -> None:
 
-        e = QuestListElement(
-            report.quest_id,
-            report.chapter,
-            report.place,
-            report.timestamp,
-            report.is_freequest,
-        )
+        e = QuestListElement(report.chapter, report.place, report.timestamp)
 
         if e.quest_id not in self.quest_dict:
             self.quest_dict[e.quest_id] = e

--- a/harvest/chalicelib/twitter.py
+++ b/harvest/chalicelib/twitter.py
@@ -404,28 +404,10 @@ class RunReport:
 
     @property
     def is_freequest(self) -> bool:
-        isfq = freequest.defaultDetector.is_freequest(self.chapter, self.place)
-        if isfq:
-            return True
-        bestmatch = freequest.defaultDetector.search_bestmatch_freequest(
-            f'{self.chapter} {self.place}'.strip(),
-        )
-        if bestmatch:
-            return True
-        return False
+        return freequest.defaultDetector.is_freequest(self.chapter, self.place)
 
     @property
     def quest_id(self) -> str:
-        if not freequest.defaultDetector.is_freequest(
-            self.chapter,
-            self.place,
-        ):
-            bestmatch = freequest.defaultDetector.search_bestmatch_freequest(
-                f'{self.chapter} {self.place}'.strip(),
-            )
-            if bestmatch:
-                return bestmatch
-
         return freequest.defaultDetector.get_quest_id(
             self.chapter, self.place, self.timestamp.year,
         )
@@ -536,7 +518,6 @@ def parse_tweet(tweet: TweetCopy) -> RunReport:
 
         if candidate:
             location_tokens = candidate
-
         else:
             # 該当するフリクエが見つからなかった。
             # place が空文字列の location として扱う。

--- a/harvest/chalicelib/twitter_test.py
+++ b/harvest/chalicelib/twitter_test.py
@@ -1,8 +1,6 @@
 from collections import namedtuple
 from datetime import datetime
 
-import pytest
-
 from . import timezone
 from . import twitter
 
@@ -56,56 +54,3 @@ QP(+194千)50-QP(+195千)58
         'QP(+194千)': '50',
         'QP(+195千)': '58',
     }
-
-
-runreport0 = """【大江山 鬼の住み処】100周
-鬼灯11-狂骨38-狂の秘石3-狂の輝石33-叡智の猛火4
-#FGO周回カウンタ http://aoshirobo.net/fatego/rc/
-"""
-
-runreport1 = """【地獄界曼荼羅　平安京　三条三坊　鬼の遊び場】340周
-鬼炎鬼灯42-糸玉75
-#FGO周回カウンタ http://aoshirobo.net/fatego/rc/
-"""
-
-runreport2 = """【ドレッドノート級】50周
-礼装2
-ランプ11-塵18-証19
-術魔5-狂魔5-術輝7
-術モ15
-鋭歯1305-ヒレ1340-ウニ2751
-#FGO周回カウンタ https://aoshirobo.net/fatego/rc/
-"""
-
-testdata_runreport = [
-    (runreport0, '大江山', '鬼の住み処', True, '20g12'),
-    (runreport1, '地獄界曼荼羅 平安京 三条三坊', '鬼の遊び場', True, '20g13'),
-    (runreport2, 'ドレッドノート級', '', False, 'M0IrmeBMeC6A'),
-]
-
-
-@pytest.mark.parametrize(
-    'text,chapter,place,is_freequest,qid',
-    testdata_runreport,
-)
-def test_runreport(
-    text: str,
-    chapter: str,
-    place: str,
-    is_freequest: bool,
-    qid: str,
-):
-    user = MockUser('testuser')
-    original_tweet = MockTweet(
-        1234567890,
-        user,
-        text,
-        datetime(2020, 1, 2, 3, 4, 5),
-    )
-
-    tw = twitter.TweetCopy(original_tweet)
-    parsed = twitter.parse_tweet(tw)
-    assert parsed.chapter == chapter
-    assert parsed.place == place
-    assert parsed.is_freequest == is_freequest
-    assert parsed.quest_id == qid

--- a/harvest/requirements-dev.txt
+++ b/harvest/requirements-dev.txt
@@ -1,9 +1,9 @@
 -i https://pypi.org/simple
 attrs==20.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-boto3==1.16.31
-botocore==1.19.31
-certifi==2020.12.5
-chalice==1.21.5
+boto3==1.16.25
+botocore==1.19.25
+certifi==2020.11.8
+chalice==1.21.4
 chardet==3.0.4
 click==7.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 enum-compat==0.0.3
@@ -26,7 +26,6 @@ pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3
 pysocks==1.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pytest==6.1.2
 python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-python-levenshtein==0.12.0
 pyyaml==5.3.1
 requests-oauthlib==1.3.0
 requests[socks]==2.25.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
@@ -38,4 +37,4 @@ tweepy==3.9.0
 typed-ast==1.4.1
 typing-extensions==3.7.4.3
 urllib3==1.26.2; python_version != '3.4'
-wheel==0.36.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+wheel==0.35.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/harvest/requirements.txt
+++ b/harvest/requirements.txt
@@ -1,9 +1,9 @@
 -i https://pypi.org/simple
 attrs==20.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-boto3==1.16.31
-botocore==1.19.31
-certifi==2020.12.5
-chalice==1.21.5
+boto3==1.16.25
+botocore==1.19.25
+certifi==2020.11.8
+chalice==1.21.4
 chardet==3.0.4
 click==7.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 enum-compat==0.0.3
@@ -16,7 +16,6 @@ mypy==0.790
 oauthlib==3.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pysocks==1.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-python-levenshtein==0.12.0
 pyyaml==5.3.1
 requests-oauthlib==1.3.0
 requests[socks]==2.25.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
@@ -26,4 +25,4 @@ tweepy==3.9.0
 typed-ast==1.4.1
 typing-extensions==3.7.4.3
 urllib3==1.26.2; python_version != '3.4'
-wheel==0.36.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+wheel==0.35.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'


### PR DESCRIPTION
#47 を取り消す。
がんばってフリクエであるかどうかの判定をやった結果として、投稿ヘッダーの `【上級】` が修練場と判定されてしまうようになった。ad hoc な対応で逃げることもできないわけではないが、今後もことも考えメリットとデメリットを天秤にかけるとデメリットの方が大きいと判断。

Revert "Merge pull request #47 from fgosc/feature/error_correction"

This reverts commit e709989cd118fdd32e67bab2a9e46186db98b3ca, reversing
changes made to 83fdcc025481785a53cc1470de0d26c146a0ef71.