### PR TITLE
NG判定方法を変更。

### DIFF
--- a/harvest/chalicelib/settings.py.example
+++ b/harvest/chalicelib/settings.py.example
@@ -3,8 +3,8 @@ TwitterConsumerSecret = ''
 TwitterAccessToken = ''
 TwitterAccessTokenSecret = ''
 
-NGWords = (
-)
+NGWords = []
+NGTags = []
 
 LatestTweetIDFile = 'latest_tweet.txt'
 CensoredAccountsFile = 'censored_accounts.json'

--- a/harvest/chalicelib/twitter_test.py
+++ b/harvest/chalicelib/twitter_test.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from datetime import datetime
+from unittest import mock
 
 import pytest
 
@@ -153,3 +154,23 @@ def test_runreport(
     assert parsed.place == place
     assert parsed.is_freequest == is_freequest
     assert parsed.quest_id == qid
+
+
+testdata_appropriate = [
+    ('', ('#OKTagA', "#FGO周回カウンタ"), True),
+    ('', ('#NGTagA', '#FGO周回カウンタ'), False),
+    ('', ('#NGTagB', '#FGO周回カウンタ'), False),
+    ('NGWordA', ('#OKTagA', "#FGO周回カウンタ"), False),
+    ('NGWordB', ('#OKTagA', '#FGO周回カウンタ'), False),
+    ('NGWordA', ('#NGTagB', '#FGO周回カウンタ'), False),
+]
+
+
+@pytest.mark.parametrize(
+    'username,hashtags,expected',
+    testdata_appropriate,
+)
+@mock.patch('chalicelib.settings.NGWords', new=('NGWordA', 'NGWordB'))
+@mock.patch('chalicelib.settings.NGTags', new=('#NGTagA', '#NGTagB'))
+def test_appropriate_tweet(username, hashtags, expected):
+    assert twitter.appropriate_tweet(username, hashtags) == expected


### PR DESCRIPTION
https://twitter.com/max747_fgo/status/1431909665793720323

ハッシュタグ3つ以上という条件はごくまれに該当する正規アカウントが存在してしまう。そこで NG となるタグを設定ファイルで明示し、これに該当するツイートをしている者をNGとする方針に変更。