### PR TITLE
CSV レンダリング時の後方互換の考慮が不足していた

### DIFF
--- a/harvest/chalicelib/recording.py
+++ b/harvest/chalicelib/recording.py
@@ -785,7 +785,8 @@ class CSVPageProcessor:
                 helper.nvl(r["tweet_id"]),
                 r["reporter_id"],
                 r["reporter"],
-                r["reporter_name"],
+                # NOTE: 古いデータは reporter_name を持たないことがある
+                helper.nvl(r.get("reporter_name", "")),
                 r["chapter"],
                 r["place"],
                 r["runcount"],


### PR DESCRIPTION
recorder.save() で古いデータ original_json と merge するとき、original_json のほうは RunReport に復元されずにそのまま JSON として渡される。 #87 で新しく追加した属性は original_json には存在しないため、存在することを前提とした属性アクセスではエラーになる。

取り急ぎ、属性が存在しない場合でもエラーとならないように修正した。
original_json を一度 retrieve してから再度 JSON 化し、それを merge するほうがより安全かもしれない。今後の TODO とする。